### PR TITLE
Make theme more similar to Casper theme

### DIFF
--- a/layout/casper/header.ejs
+++ b/layout/casper/header.ejs
@@ -1,0 +1,9 @@
+<header class="site-head" <% if (theme.cover) { %> style="background-image: url(<%- theme.cover %>)" <% } %>>
+    <div class="vertical">
+        <div class="site-head-content inner">
+            <% if (theme.logo) { %> <a class="blog-logo" href="<%- config.root %>"><img src="<%- theme.logo %>" alt="Blog Logo"/></a> <% } %>
+            <h1 class="blog-title"><%- config.title %></h1>
+            <h2 class="blog-description"><%- config.subtitle %></h2>
+        </div>
+    </div>
+</header>

--- a/layout/casper/index.ejs
+++ b/layout/casper/index.ejs
@@ -1,22 +1,9 @@
 
-<header class="site-head" <% if (theme.cover) { %> style="background-image: url(<%- theme.cover %>)" <% } %>>
-  <div class="vertical">
-    <div class="site-head-content inner">
-      <% if (theme.logo) { %> <a class="blog-logo" href="<%- config.root %>"><img src="<%- theme.logo %>" alt="Blog Logo"/></a> <% } %>
-      <h1 class="blog-title"><%- config.title %></h1>
-      <h2 class="blog-description"><%- config.subtitle %></h2>
-    </div>
-  </div>
-</header>
-
 <main class="content" role="main">
   <% page.posts.each(function(post) { %>
   <article class="post">
     <header class="post-header">
-      <span class="post-meta">
-        <time datetime="<%= date_xml(post.date) %>" itemprop="datePublished"><%= date(post.date, null) %></time>
-        <% if (post.tags && post.tags.length){ %> on <% post.tags.forEach(function(tag) { %><a href='<%= config.root + tag.path %>' style='margin:0 5px;'><%= tag.name %></a><% }); %><% } %>
-      </span>
+      <%- partial('post/meta', {post: post}) %>
       <h2 class="post-title"><a href="<%- config.root %><%- post.path %>"><%- post.title %></a></h2>
     </header>
     <section class="post-excerpt">
@@ -36,8 +23,8 @@
   </article>
   <% }); %>
   <nav class="pagination" role="pagination">
-    <% if (page.prev) { %><a class="newer-posts" href="<%- config.root %><%- page.prev_link %>">← Newer Posts</a><% } %>
+    <% if (page.prev) { %><a class="newer-posts" href="<%- url_for(page.prev_link) %>">← Newer Posts</a><% } %>
     <span class="page-number">Page <%- page.current %> of <%- page.total %></span>
-    <% if (page.next) { %><a class="older-posts" href="<%- config.root %><%- page.next_link %>">Older Posts →</a><% } %>
+    <% if (page.next) { %><a class="older-posts" href="<%- url_for(page.next_link) %>">Older Posts →</a><% } %>
   </nav>
 </main>

--- a/layout/casper/post.ejs
+++ b/layout/casper/post.ejs
@@ -2,53 +2,16 @@
 <% permalink = config.url + config.root + post.path %>
 <main class="content" role="main">
   <article class="post">
-    <header class="post-header">
-      <a class="blog-logo" href="<%- config.root %>">
-        <% if (theme.logo) { %>
-        <img src="<%- theme.logo %>" alt="Blog Logo"/></a>
-        <% } else { %>
-        <span class="blog-title"><%- config.title %></span>
-        <% } %>
-      </a>
-    </header>
-    <span class="post-meta">
-      <time datetime="<%= date_xml(post.date) %>" itemprop="datePublished"><%= date(post.date, null) %></time>
-      <% if (post.tags && post.tags.length){ %> on <% post.tags.forEach(function(tag) { %><a href='<%= config.root + tag.path %>' style='margin:0 5px;'><%= tag.name %></a><% }); %><% } %>
-    </span>
+    <%- partial('post/meta') %>
     <h1 class="post-title"><%- post.title %></h1>
     <section class="post-content">
       <%- post.content %>
     </section>
-      <section id="comment">
-          <h1 class="title">Comments</h1>
-
-          <% if(config.disqus_shortname) { %>
-          <div id="disqus_thread">
-              <noscript>Please enable JavaScript to view the <a href="//disqus.com/?ref_noscript">comments powered by Disqus.</a></noscript>
-          </div>
-          <% } %>
-      </section>
     <footer class="post-footer">
-      <section class="author">
-        <h4><%- config.author %></h4>
-        <p><%- theme.bio %></p>
-      </section>
-
-      <section class="share">
-        <h4>Share this post</h4>
-        <a class="icon-twitter" href="http://twitter.com/share?url=<%- permalink %>"
-          onclick="window.open(this.href, 'twitter-share', 'width=550,height=235');return false;">
-          <span class="hidden">Twitter</span>
-        </a>
-        <a class="icon-facebook" href="https://www.facebook.com/sharer/sharer.php?u=<%- permalink %>"
-          onclick="window.open(this.href, 'facebook-share','width=580,height=296');return false;">
-          <span class="hidden">Facebook</span>
-        </a>
-        <a class="icon-google-plus" href="https://plus.google.com/share?url=<%- permalink %>"
-           onclick="window.open(this.href, 'google-plus-share', 'width=490,height=530');return false;">
-          <span class="hidden">Google+</span>
-        </a>
-      </section>
+      <%- partial('post/author') %>
+      <%- partial('post/share') %>
     </footer>
   </article>
+  <%- partial('post/navigation') %>
+  <%- partial('post/comments') %>
 </main>

--- a/layout/casper/post/author.ejs
+++ b/layout/casper/post/author.ejs
@@ -1,0 +1,4 @@
+<section class="author">
+    <h4><%- config.author %></h4>
+    <p><%- theme.bio %></p>
+</section>

--- a/layout/casper/post/comments.ejs
+++ b/layout/casper/post/comments.ejs
@@ -1,5 +1,5 @@
 <div id="comment" class="comments-area">
-    <h1 class="title">Comments</h1>
+    <h1 class="title"><a href="#disqus_comments" name="disqus_comments">Comments</a></h1>
 
     <% if(config.disqus_shortname) { %>
     <div id="disqus_thread">

--- a/layout/casper/post/comments.ejs
+++ b/layout/casper/post/comments.ejs
@@ -1,0 +1,9 @@
+<div id="comment" class="comments-area">
+    <h1 class="title">Comments</h1>
+
+    <% if(config.disqus_shortname) { %>
+    <div id="disqus_thread">
+        <noscript>Please enable JavaScript to view the <a href="//disqus.com/?ref_noscript">comments powered by Disqus.</a></noscript>
+    </div>
+    <% } %>
+</div>

--- a/layout/casper/post/meta.ejs
+++ b/layout/casper/post/meta.ejs
@@ -1,0 +1,11 @@
+<span class="post-meta">
+      <time datetime="<%= date_xml(post.date) %>" itemprop="datePublished">
+          <%= date(post.date, null) %>
+      </time>
+    <% if (post.tags && post.tags.length){ %>
+    <% count = post.tags.length %>
+    | <% post.tags.forEach(function(tag, index) { %>
+    <a href='<%= config.root + tag.path %>'><%= tag.name %></a><% if (count !== index+1) { %>,<% } %>
+    <% }); %>
+    <% } %>
+</span>

--- a/layout/casper/post/navigation.ejs
+++ b/layout/casper/post/navigation.ejs
@@ -1,0 +1,13 @@
+<nav class="pagination" role="pagination">
+    <% if (page.prev) { %>
+    <a class="newer-posts" href="<%- url_for(page.prev.path) %>">
+        ← <%- page.prev.title %>
+    </a>
+    <% } %>
+    <span class="page-number">•</span>
+    <% if (page.next) { %>
+    <a class="older-posts" href="<%- url_for(page.next.path) %>">
+        <%- page.next.title %> →
+    </a>
+    <% } %>
+</nav>

--- a/layout/casper/post/share.ejs
+++ b/layout/casper/post/share.ejs
@@ -1,0 +1,15 @@
+<section class="share">
+    <h4>Share this post</h4>
+    <a class="icon-twitter" href="http://twitter.com/share?url=<%- permalink %>"
+       onclick="window.open(this.href, 'twitter-share', 'width=550,height=235');return false;">
+        <span class="hidden">Twitter</span>
+    </a>
+    <a class="icon-facebook" href="https://www.facebook.com/sharer/sharer.php?u=<%- permalink %>"
+       onclick="window.open(this.href, 'facebook-share','width=580,height=296');return false;">
+        <span class="hidden">Facebook</span>
+    </a>
+    <a class="icon-google-plus" href="https://plus.google.com/share?url=<%- permalink %>"
+       onclick="window.open(this.href, 'google-plus-share', 'width=490,height=530');return false;">
+        <span class="hidden">Google+</span>
+    </a>
+</section>

--- a/layout/layout.ejs
+++ b/layout/layout.ejs
@@ -6,6 +6,7 @@
 <% } else { %>
 <body class="post-template">
 <% } %>
+  <%- partial('casper/header') %>
   <%- body %>
   <%- partial('casper/footer') %>
   <%- partial('casper/after_all') %>

--- a/source/css/screen.css
+++ b/source/css/screen.css
@@ -521,6 +521,10 @@ margin on the iframe, cause it breaks stuff. */
     margin: 4rem auto;
 }
 
+#comment h1 a {
+    text-decoration: none;
+}
+
 /* ==========================================================================
    5. Single Post - When you click on an individual post
    ========================================================================== */

--- a/source/css/screen.css
+++ b/source/css/screen.css
@@ -515,21 +515,15 @@ margin on the iframe, cause it breaks stuff. */
     line-height: 1.5em;
 }
 
+.comments-area {
+    width: 80%;
+    max-width: 700px;
+    margin: 4rem auto;
+}
+
 /* ==========================================================================
    5. Single Post - When you click on an individual post
    ========================================================================== */
-
-/* Tweak the .post wrapper style */
-.post-template .post {
-    margin-top: 0;
-    border-bottom: none;
-    padding-bottom: 0;
-}
-
-/* Kill that stylish little circle that was on the border, too */
-.post-template .post:after {
-    display: none;
-}
 
 /* Insert some mad padding up in the header for better spacing */
 .post-template .post-header {
@@ -537,9 +531,27 @@ margin on the iframe, cause it breaks stuff. */
     text-align: center;
 }
 
-.post-template .blog-title {
-    display: inline-block;
-    padding: 2.5rem 0;
+.post-template .site-head {
+    color: #303538;
+    border-bottom: #ebf2f6 1px solid;
+    background: none !important;
+}
+
+.post-template .site-head:after {
+    position: absolute;
+    bottom: -5px;
+    left: 50%;
+    display: block;
+    width: 7px;
+    height: 7px;
+    margin-left: -5px;
+    content: '';
+    border: #e7eef2 1px solid;
+    -webkit-border-radius: 100%;
+    -moz-border-radius: 100%;
+    border-radius: 100%;
+    background: #fff;
+    box-shadow: #fff 0 0 0 5px;
 }
 
 /* Keep large images within the bounds of the post-width */
@@ -1066,10 +1078,6 @@ pre .chunk {
 
     h4 {
         font-size: 2.3rem;
-    }
-
-    .post-template .post {
-        padding-bottom: 0;
     }
 
     .post-template .post-header {


### PR DESCRIPTION
Makes a number of tweaks and refactorings to make this hexo theme more
closely resemble [the Casper theme](https://github.com/TryGhost/Casper) ([this page](http://lacymorrow.com/projects/casper/) used as reference).

Changes include:
- Adding next post / previous post links to the bottom of a post
- Reusing the existing site header for pages / posts
  - Disable the cover photo and change text from white to black on
    pages / posts
- Re-order comments section to _after_ bio, sharing links
- Change how tags are listed (`| <tag>, <tag>` instead of `on <tag>
  <tag>`)
- Re-added curlicue (circle thingy) to top and bottom of articles
